### PR TITLE
Remoção temporária da contagem de notificações

### DIFF
--- a/src/components/navbar.vue
+++ b/src/components/navbar.vue
@@ -308,24 +308,28 @@
       }
     },
 
-    created: function () {
-      this.fetchUnreadsCount();
+    // XXX: Código comentado temporiariamente até ser realizado
+    // o ajuste na performance de notificações
+    // created: function () {
+    //   this.fetchUnreadsCount();
 
-      // Cliente solicitou configurar a cada 5 minutos.
-      this.interval = setInterval(function () {
-        this.fetchUnreadsCount();
-      }.bind(this), 300000); 
-    },
+    //   // Cliente solicitou configurar a cada 5 minutos.
+    //   this.interval = setInterval(function () {
+    //     this.fetchUnreadsCount();
+    //   }.bind(this), 300000);
+    // },
 
     beforeDestroy: function(){
       clearInterval(this.interval);
     },
 
-    watch:{
-      $route (to, from){
-        this.fetchUnreadsCount();
-      }
-    }
+    // XXX: Código comentado temporiariamente até ser realizado
+    // o ajuste na performance de notificações
+    // watch:{
+    //   $route (to, from){
+    //     this.fetchUnreadsCount();
+    //   }
+    // }
   }
 
 </script>

--- a/src/components/navbar.vue
+++ b/src/components/navbar.vue
@@ -319,9 +319,11 @@
     //   }.bind(this), 300000);
     // },
 
-    beforeDestroy: function(){
-      clearInterval(this.interval);
-    },
+    // XXX: Código comentado temporiariamente até ser realizado
+    // o ajuste na performance de notificações
+    // beforeDestroy: function(){
+    //   clearInterval(this.interval);
+    // },
 
     // XXX: Código comentado temporiariamente até ser realizado
     // o ajuste na performance de notificações


### PR DESCRIPTION
- A contagem de notificações está consumindo muito recurso devido à consulta ao banco de dados. Foi removida a exibição da contagem, temporiariamente, até realizar o ajuste na performance.

---

![image](https://user-images.githubusercontent.com/8549327/184403859-26bbe55e-0e68-4bc4-a274-686f89d8af13.png)
